### PR TITLE
Refer JAVA_HOME to find header files.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ description = """Java bindings for libstorj"""
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
+def javaHome = System.getenv("JAVA_HOME")
+
 repositories {
     mavenCentral()
 }
@@ -74,8 +76,8 @@ model {
                     args << "-c"
                     args << "-Wall"
                     args << "-fPIC"
-                    args << "-I/usr/lib/jvm/java/include"
-                    args << "-I/usr/lib/jvm/java/include/linux"
+                    args << "-I${javaHome}/include"
+                    args << "-I${javaHome}/include/linux"
                 }
                 linker.withArguments { args ->
                     args << "-fPIC"


### PR DESCRIPTION
Location of JDK's header files is dependent on the environment, I think it is better to refer JAVA_HOME instead of hard-coding.