### PR TITLE
Build macOS libraries in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,60 @@
+osx_image: xcode9.2
+dist: trusty
+language: java
+sudo: true
+os:
+- osx
+env:
+  global:
+  - LD_LIBRARY_PATH=/usr/local/lib
+  - JAVA_HOME=$(/usr/libexec/java_home)
+  - LIBSTORJ_VERSION=2.0.0-beta2
+install:
+- brew install -v curl libuv libmicrohttpd
+- curl -sSL https://github.com/Storj/libstorj/archive/v$LIBSTORJ_VERSION.tar.gz | tar -zxv
+- (cd libstorj-$LIBSTORJ_VERSION && ./autogen.sh && CC=clang CFLAGS="-g -O2 -O3 -std=gnu99" ./configure && make && sudo make install)
+script:
+- LD_LIBRARY_PATH=$(pwd)/libstorj-$LIBSTORJ_VERSION/lib:/usr/local/lib:/usr/local/opt/curl/lib INCLIDE=$(pwd)/libstorj-$LIBSTORJ_VERSION/include ./gradlew jniSharedLibrary --info
+- ./gradlew assemble
+# - ./gradlew test --debug
+before_cache:
+- rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+  - "$HOME/.gradle/caches/"
+  - "$HOME/.gradle/wrapper/"
+  - "$HOME/Library/Caches/Homebrew"
+before_deploy:
+- cd build/libs/jni/shared/
+- cp /usr/local/lib/libstorj.2.dylib .
+- cp /usr/lib/libcurl.4.dylib .
+- cp /usr/local/opt/nettle/lib/libnettle.6.dylib .
+- cp /usr/local/opt/json-c/lib/libjson-c.2.dylib .
+- cp /usr/local/opt/libuv/lib/libuv.1.dylib .
+- chmod 666 *.dylib
+- install_name_tool -id libstorj.2.dylib libstorj.2.dylib
+- install_name_tool -id libcurl.4.dylib libcurl.4.dylib
+- install_name_tool -id libnettle.6.dylib libnettle.6.dylib
+- install_name_tool -id libjson-c.2.dylib libjson-c.2.dylib
+- install_name_tool -id libuv.1.dylib libuv.1.dylib
+- install_name_tool -change /usr/local/lib/libstorj.2.dylib libstorj.2.dylib libstorj-java.dylib
+- install_name_tool -change /usr/lib/libcurl.4.dylib libcurl.4.dylib libstorj-java.dylib
+- install_name_tool -change /usr/local/opt/json-c/lib/libjson-c.2.dylib libjson-c.2.dylib libstorj-java.dylib
+- install_name_tool -change /usr/local/opt/nettle/lib/libnettle.6.dylib libnettle.6.dylib libstorj-java.dylib
+- install_name_tool -change /usr/local/opt/libuv/lib/libuv.1.dylib libuv.1.dylib libstorj-java.dylib
+- install_name_tool -change /usr/lib/libcurl.4.dylib libcurl.4.dylib libstorj.2.dylib
+- install_name_tool -change /usr/local/opt/json-c/lib/libjson-c.2.dylib libjson-c.2.dylib libstorj.2.dylib
+- install_name_tool -change /usr/local/opt/nettle/lib/libnettle.6.dylib libnettle.6.dylib libstorj.2.dylib
+- install_name_tool -change /usr/local/opt/libuv/lib/libuv.1.dylib libuv.1.dylib libstorj.2.dylib
+- tar -zcf java-libstorj-$TRAVIS_TAG-macos-dylibs.tar.gz *.dylib
+- cd ../../../../
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key: GITHUB_TOKEN
+  file:
+  - build/libs/jni/shared/java-libstorj-$TRAVIS_TAG-macos-dylibs.tar.gz
+  on:
+    repo: Storj/java-libstorj
+    tags: true

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,28 @@ model {
         }
     }
     toolChains {
+        clang(Clang){
+            eachPlatform {
+                cppCompiler.withArguments { args ->
+                    args << "-c"
+                    args << "-Wall"
+                    args << "-fPIC"
+                    args << "-v"
+                    args << "-I${javaHome}/include"
+                    args << "-I${javaHome}/include/darwin"
+                }
+                linker.withArguments { args ->
+                    args << "-fPIC"
+                    args << "-shared"
+                    args << "-lstorj"
+                    args << "-lcurl"
+                    args << "-ljson-c"
+                    args << "-lnettle"
+                    args << "-luv"
+                    args << "-v"
+                }
+            }
+        }
         gcc(Gcc) {
             eachPlatform {
                 cppCompiler.withArguments { args ->
@@ -105,7 +127,7 @@ def pomConfig = {
             organizationUrl "https://storj.io"
         }
     }
-    
+
     scm {
         connection "scm:git:git://github.com/Storj/java-libstorj.git"
         developerConnection "scm:git:ssh://github.com:Storj/java-libstorj.git"


### PR DESCRIPTION
This PR provides Travis CI's configuration file to build macOS libraries in it. 

With this configuration file, when a tag is pushed to GitHub, Travis CI builds libstorj and dependent libraries, and then uploads them to GitHub releases as a tarballed file.

To upload files, the configuration file requires GitHub token (in line 55 of `.travis.yml`). To set the token, run 
```
travis setup releases
```

with the [Travis CI command line client](https://github.com/travis-ci/travis.rb#installation). 

Here is the [link to the detailed document](https://docs.travis-ci.com/user/deployment/releases/).

